### PR TITLE
Add some use-case helper utilities

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,9 @@
+import { APCAcontrast, sRGBtoY } from "apca-w3";
+import { colorParsley } from "colorparsley";
+
+const shouldUseDarkText = (color) => {
+    const testColor = colorParsley(color)
+    return Math.abs(APCAcontrast(sRGBtoY(colorParsley("black")), sRGBtoY(testColor))) >= Math.abs(APCAcontrast(sRGBtoY(colorParsley("white")), sRGBtoY(testColor)))
+}
+
+export { shouldUseDarkText }


### PR DESCRIPTION
First off, great work on apca, and congrats on publishing it to npm! It's the only algorithm I've used that properly identifies perceived contrast.

There isn't an issue tracker on this repo, so I figured I'd go with this; it probably won't compile, but hopefully it gets the point across.

--

My main use case for this library is determining whether I should use a light or dark color for the foreground text on a background that has a certain color (``testColor`` in the PR code). I'd love to see a helper util similar to this make it in to the library so that people that have this same use case can easily swap apca into their current workflow.