### PR TITLE
Main sources should properly require dependencies

### DIFF
--- a/src/apca-w3.js
+++ b/src/apca-w3.js
@@ -28,6 +28,8 @@
 // */
 ///////////////////////////////////////////////////////////////////////////////
 
+const { colorParsley } = require("colorparsley")
+
 // ==ClosureCompiler==
 // @compilation_level SIMPLE_OPTIMIZATIONS
 // @output_file_name apca-w3.min.js


### PR DESCRIPTION
Creating this largely as a discussion topic (since issues aren't open).    Can dependencies please be handled properly such that using this from `nodejs` "just works" - like with every NPM libraries - ie, libraries (in raw form) should require their own dependencies...  Users should not be forced to rely on globals just to use the library from Node proper.

I do think the final distributable would be improved if it also bundled `colorparsley` (a tiny dependency) rather than forcing client-side users to deal with dependency hell, but that's a secondary issue.

---

Also: Can the fact that this is a template repo be fixed and could issues be opposed to allow people to file issues?